### PR TITLE
Fixed handling of http response code "0"

### DIFF
--- a/addons/quiver_leaderboards/leaderboards.gd
+++ b/addons/quiver_leaderboards/leaderboards.gd
@@ -127,6 +127,9 @@ func post_guest_score(leaderboard_id: String, score: float, nickname := "", meta
 				printerr("[Quiver Leaderboards] There was an irrecoverable error posting a score.")
 				retry = false
 				success = false
+			elif response_code == 0:
+				printerr("[Quiver Leaderboards] There was an error posting a score.")
+				success = false
 		_http_post_request_busy = false
 
 	if not success and retry:


### PR DESCRIPTION
Bug encountered where the http "response_code" would return "0" when not connected to the internet. This error stopped the leaderboard queue from initialising in a local file, therefore not allowing a player score to be saved and updated to the online leaderboard when connection was eventually restored. This is because in this instance the "success" variable in the "post_guest_score" function stayed "true" even though the score failed to post.

Updated code can handle this instance and allows the plugin to function as intended when the "response_code" returns "0" upon a failed network connection. The code catches the response code and sets "success" to false, setting in motion the required steps that are necessary for the plugin to function as intended when the user score cannot be posted to the online leaderboard.

Upon testing the updated code, the plugin functions as intended and the bug is fixed.